### PR TITLE
Listen on all IPs

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ fastify.get('/', async (request, reply) => {
 // Run the server!
 const start = async () => {
   try {
-    await fastify.listen(process.env.PORT || 3000)
+    await fastify.listen(process.env.PORT || 3000, "0.0.0.0")
     fastify.log.info(`server listening on ${fastify.server.address().port}`)
   } catch (err) {
     fastify.log.error(err)


### PR DESCRIPTION
By default, it was only listening on localhost. On Fly it needs to be able to accept traffic on other IPs, this change just makes the process bind to all the IPs.